### PR TITLE
Change `codon_data` to a `data.frame`

### DIFF
--- a/OLGenie_sliding_windows.R
+++ b/OLGenie_sliding_windows.R
@@ -99,7 +99,6 @@ if(! is.na(ARGV[10])) {
 #PREPEND_TO_OUTPUT <- ''
 
 ### Read in the file
-#suppressMessages(codon_data <- read_tsv(file = CODON_RESULTS_FILE))
 codon_data <- as.data.frame(read_tsv(file = CODON_RESULTS_FILE))
 if(length(paste0(codon_data$frame, '_', codon_data$codon_num)) != unique(length(paste0(codon_data$frame, '_', codon_data$codon_num)))) {
   cat("\n\n### WARNING: there must only be results for ONE GENE PRODUCT PER FILE, i.e., a unique set of codons per frame.:\n")

--- a/OLGenie_sliding_windows.R
+++ b/OLGenie_sliding_windows.R
@@ -99,7 +99,8 @@ if(! is.na(ARGV[10])) {
 #PREPEND_TO_OUTPUT <- ''
 
 ### Read in the file
-suppressMessages(codon_data <- read_tsv(file = CODON_RESULTS_FILE))
+#suppressMessages(codon_data <- read_tsv(file = CODON_RESULTS_FILE))
+codon_data <- as.data.frame(read_tsv(file = CODON_RESULTS_FILE))
 if(length(paste0(codon_data$frame, '_', codon_data$codon_num)) != unique(length(paste0(codon_data$frame, '_', codon_data$codon_num)))) {
   cat("\n\n### WARNING: there must only be results for ONE GENE PRODUCT PER FILE, i.e., a unique set of codons per frame.:\n")
   quit(save = 'no', status = 1, runLast = TRUE)


### PR DESCRIPTION
This fixes the problem where the example data could not be read.

Here is the error that I got.
```bash
$ Rscript OLGenie_sliding_windows.R EXAMPLE_OUTPUT/OLGenie_codon_results_ex22.txt NN NS 25 1 1000 6 NONE 6 > OLGenie_sliding_windows.out 
Error in sum(as.vector(codon_results[, paste0(numerator, "_diffs")]), : invalid 'type' (list) of argument Calls: dNdS_diff_boot_fun Execution halted
```